### PR TITLE
Mask features

### DIFF
--- a/stitching/cli/stitch.py
+++ b/stitching/cli/stitch.py
@@ -251,7 +251,12 @@ parser.add_argument(
     help="The default is 'result.jpg'",
     type=str,
 )
-
+parser.add_argument(
+    "--mask_names",
+    nargs='*',
+    action="store",
+    type=str,
+)
 __doc__ += "\n" + parser.format_help()
 
 
@@ -274,8 +279,15 @@ def main():
         stitcher = AffineStitcher(**args_dict)
     else:
         stitcher = Stitcher(**args_dict)
-
-    panorama = stitcher.stitch(img_names)
+    
+    mask_names = args_dict.pop("mask_names")
+    if mask_names is not None and len(mask_names) != len(img_names):
+        raise Exception('img_names and masks should have the same length')
+    
+    if mask_names is not None:
+        panorama = stitcher.stitch(img_names, mask_names)
+    else:
+        panorama = stitcher.stitch(img_names)
 
     cv.imwrite(output, panorama)
 

--- a/stitching/cli/stitch.py
+++ b/stitching/cli/stitch.py
@@ -282,7 +282,7 @@ def main():
     
     mask_names = args_dict.pop("mask_names")
     if mask_names is not None and len(mask_names) != len(img_names):
-        raise Exception('img_names and masks should have the same length')
+        raise Exception('img_names ('+str(len(img_names))+') and masks ('+str(len(mask_names))+')  should have the same length')
     
     if mask_names is not None:
         panorama = stitcher.stitch(img_names, mask_names)

--- a/stitching/image_handler.py
+++ b/stitching/image_handler.py
@@ -68,7 +68,7 @@ class ImageHandler:
     
     @staticmethod
     def binary_img(img):
-        thr, bin = cv.threshold(cv.cvtColor(img, cv.COLOR_BGR2GRAY), 0.1, 255.0, cv.THRESH_BINARY);
+        _, bin = cv.threshold(cv.cvtColor(img, cv.COLOR_BGR2GRAY), 127, 255, cv.THRESH_BINARY);
         return bin
 
     def input_images(self):

--- a/stitching/image_handler.py
+++ b/stitching/image_handler.py
@@ -40,6 +40,11 @@ class ImageHandler:
     def resize_to_medium_resolution(self):
         return self.read_and_resize_imgs(self.medium_scaler)
 
+    def to_medium_resolution_binary_mask(self):
+        for img, size in self.input_images():
+            img_medium = self.resize_img_by_scaler(self.medium_scaler, size, img)
+            yield self.binary_img(img_medium)
+
     def resize_to_low_resolution(self, medium_imgs=None):
         if medium_imgs and self.scales_set:
             return self.resize_imgs_by_scaler(medium_imgs, self.low_scaler)
@@ -60,6 +65,11 @@ class ImageHandler:
     def resize_img_by_scaler(scaler, size, img):
         desired_size = scaler.get_scaled_img_size(size)
         return cv.resize(img, desired_size, interpolation=cv.INTER_LINEAR_EXACT)
+    
+    @staticmethod
+    def binary_img(img):
+        thr, bin = cv.threshold(cv.cvtColor(img, cv.COLOR_BGR2GRAY), 0.1, 255.0, cv.THRESH_BINARY);
+        return bin
 
     def input_images(self):
         self.img_sizes = []

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -105,7 +105,7 @@ class Stitcher:
         self.estimate_scale(cameras)
 
         imgs = self.resize_low_resolution(imgs)
-        imgs, masks, corners, sizes = self.warp_low_resolution(imgs, cameras)
+        imgs, masks, corners, sizes = self.warp_low_resolution(imgs, cameras, feature_masks)
         self.prepare_cropper(imgs, masks, corners, sizes)
         imgs, masks, corners, sizes = self.crop_low_resolution(
             imgs, masks, corners, sizes
@@ -114,7 +114,7 @@ class Stitcher:
         seam_masks = self.find_seam_masks(imgs, corners, masks)
 
         imgs = self.resize_final_resolution()
-        imgs, masks, corners, sizes = self.warp_final_resolution(imgs, cameras)
+        imgs, masks, corners, sizes = self.warp_final_resolution(imgs, cameras, feature_masks)
         imgs, masks, corners, sizes = self.crop_final_resolution(
             imgs, masks, corners, sizes
         )
@@ -170,20 +170,20 @@ class Stitcher:
     def resize_low_resolution(self, imgs=None):
         return list(self.img_handler.resize_to_low_resolution(imgs))
 
-    def warp_low_resolution(self, imgs, cameras):
+    def warp_low_resolution(self, imgs, cameras, feature_masks):
         sizes = self.img_handler.get_low_img_sizes()
         camera_aspect = self.img_handler.get_medium_to_low_ratio()
-        imgs, masks, corners, sizes = self.warp(imgs, cameras, sizes, camera_aspect)
+        imgs, masks, corners, sizes = self.warp(imgs, cameras, sizes, feature_masks, camera_aspect)
         return list(imgs), list(masks), corners, sizes
 
-    def warp_final_resolution(self, imgs, cameras):
+    def warp_final_resolution(self, imgs, cameras, feature_masks):
         sizes = self.img_handler.get_final_img_sizes()
         camera_aspect = self.img_handler.get_medium_to_final_ratio()
-        return self.warp(imgs, cameras, sizes, camera_aspect)
+        return self.warp(imgs, cameras, sizes, feature_masks, camera_aspect)
 
-    def warp(self, imgs, cameras, sizes, aspect=1):
+    def warp(self, imgs, cameras, sizes, feature_masks, aspect=1):
         imgs = self.warper.warp_images(imgs, cameras, aspect)
-        masks = self.warper.create_and_warp_masks(sizes, cameras, aspect)
+        masks = self.warper.create_and_warp_masks(sizes, cameras, aspect, feature_masks)
         corners, sizes = self.warper.warp_rois(sizes, cameras, aspect)
         return imgs, masks, corners, sizes
 

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -91,8 +91,11 @@ class Stitcher:
     def stitch(self, img_names, mask_names=None):
         self.initialize_registration(img_names, mask_names)
         imgs = self.resize_medium_resolution()
-        feature_masks = list(self.mask_handler.to_medium_resolution_binary_mask())
-        print('feature_masks', feature_masks, self.mask_handler.img_names)
+        if mask_names is None :
+            feature_masks = None
+        else:
+            feature_masks = list(self.mask_handler.to_medium_resolution_binary_mask())
+        
         features = self.find_features(imgs, feature_masks)
         matches = self.match_features(features)
         imgs, features, matches = self.subset(imgs, features, matches)
@@ -132,8 +135,11 @@ class Stitcher:
     def resize_medium_resolution(self):
         return list(self.img_handler.resize_to_medium_resolution())
 
-    def find_features(self, imgs, *args):
-        return [self.detector.detect_features(img, *args) for img in imgs]
+    def find_features(self, imgs, mask_features = None):
+        if mask_features is not None:
+            return [self.detector.detect_features(img, mask) for (img, mask) in zip(imgs, mask_features) ]
+        else: 
+            return [self.detector.detect_features(img) for img in imgs ]
 
     def match_features(self, features):
         return self.matcher.match_features(features)

--- a/stitching/warper.py
+++ b/stitching/warper.py
@@ -51,13 +51,20 @@ class Warper:
         )
         return warped_image
 
-    def create_and_warp_masks(self, sizes, cameras, aspect=1):
-        for size, camera in zip(sizes, cameras):
-            yield self.create_and_warp_mask(size, camera, aspect)
+    def create_and_warp_masks(self, sizes, cameras, aspect=1, feature_masks=None):
+        if feature_masks is not None:
+            for size, camera, feature_mask in zip(sizes, cameras, feature_masks):
+                yield self.create_and_warp_mask(size, camera, aspect, feature_mask)
+        else:
+            for size, camera in zip(sizes, cameras):
+                yield self.create_and_warp_mask(size, camera, aspect)
 
-    def create_and_warp_mask(self, size, camera, aspect=1):
+    def create_and_warp_mask(self, size, camera, aspect=1, feature_mask = None):
         warper = cv.PyRotationWarper(self.warper_type, self.scale * aspect)
         mask = 255 * np.ones((size[1], size[0]), np.uint8)
+        if(feature_mask is not None):
+            mask = cv.resize(feature_mask, (size[0], size[1]))
+        
         _, warped_mask = warper.warp(
             mask,
             Warper.get_K(camera, aspect),

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -13,18 +13,17 @@ class TestImageRegistration(unittest.TestCase):
         TEST_DIR = os.path.abspath(os.path.dirname(__file__))
         os.chdir(os.path.join(TEST_DIR, "testdata"))
 
-    def test_feature_detector(self):
+    def test_feature_detector_mask(self):
         img1 = cv.imread("s1.jpg")
-
+        mask = cv.imread("s1-mask.jpg")
+        thr, bin = cv.threshold(cv.cvtColor(mask, cv.COLOR_BGR2GRAY), 0.1, 255.0, cv.THRESH_BINARY);
+        
         default_number_of_keypoints = 500
         detector = FeatureDetector("orb")
-        features = detector.detect_features(img1)
+        features = detector.detect_features(img1, bin)
         self.assertEqual(len(features.getKeypoints()), default_number_of_keypoints)
-
-        other_keypoints = 1000
-        detector = FeatureDetector("orb", nfeatures=other_keypoints)
-        features = detector.detect_features(img1)
-        self.assertEqual(len(features.getKeypoints()), other_keypoints)
+        for kpt in features.getKeypoints():
+            self.assertGreater(kpt.pt[0], 650)
 
     def test_feature_matcher(self):
         img1, img2 = cv.imread("s1.jpg"), cv.imread("s2.jpg")

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -15,12 +15,12 @@ class TestImageRegistration(unittest.TestCase):
 
     def test_feature_detector_mask(self):
         img1 = cv.imread("s1.jpg")
-        mask = cv.imread("s1-mask.jpg")
-        thr, bin = cv.threshold(cv.cvtColor(mask, cv.COLOR_BGR2GRAY), 0.1, 255.0, cv.THRESH_BINARY);
-        
+        mask2 = np.zeros(img1.shape[0:2], dtype=np.uint8)
+        mask2[:,651:] = 255
+
         default_number_of_keypoints = 500
         detector = FeatureDetector("orb")
-        features = detector.detect_features(img1, bin)
+        features = detector.detect_features(img1, mask2)
         self.assertEqual(len(features.getKeypoints()), default_number_of_keypoints)
         for kpt in features.getKeypoints():
             self.assertGreater(kpt.pt[0], 650)


### PR DESCRIPTION
@lukasalexanderweber thanks for this library, very useful to play with sticthing

I need to be able to mask some features in the stitching process so some region in the image are ignored in the sticthing process.

I found other people on the web having the same needs : 
* https://answers.opencv.org/question/192008/how-to-stitch-images-by-opencv-with-masks-only-stitch-parts-of-images/
* https://stackoverflow.com/questions/73721536/how-to-stitch-images-by-opencvsharp-using-mask

I have implemented this feature in command line.

Currently i have been able to make it work like : 

```sh
python stitching/cli/stitch.py img1.png img2.png --mask_names mask1.png mask2.png --no-crop --blender_type no --finder no --compensator no --affine
```

This is a first implem and more tests need to be done, but i would like to have an early feedback as if you are open to integrate this new mask_feature capability

What do you think ?
