### PR TITLE
modifying colored_img_generator to loop over known colors.

### DIFF
--- a/stitching/seam_finder.py
+++ b/stitching/seam_finder.py
@@ -98,7 +98,8 @@ class SeamFinder:
 def colored_img_generator(sizes, colors):
     if len(sizes) + 1 > len(colors):
         warnings.warn(
-            """Without additional colors, there will be seam masks with identical colors""",
+            """Without additional colors,
+            there will be seam masks with identical colors""",
             StitchingWarning,
         )
 

--- a/stitching/seam_finder.py
+++ b/stitching/seam_finder.py
@@ -93,7 +93,7 @@ def colored_img_generator(
     ),  # Orange
 ):
     for idx, size in enumerate(sizes):
-        yield create_img_by_size(size, colors[idx%len(colors)])
+        yield create_img_by_size(size, colors[idx % len(colors)])
 
 
 def create_img_by_size(size, color=(0, 0, 0)):

--- a/stitching/seam_finder.py
+++ b/stitching/seam_finder.py
@@ -101,9 +101,10 @@ def colored_img_generator(sizes, colors):
 
     if len(sizes) + 1 > len(colors):
         print(
-            """WARNING : Not enough default colors !\n
-        Please add additional colors in a tuple. (like colors=((255, 000, 000), (000, 255, 255)).\n
-        Without additional colors, the program will loop over the default colors."""
+            """! WARNING : Not enough default colors !\n
+            Please add additional colors in a tuple.\n
+            Example of use : colors=((255, 000, 000), (000, 255, 255)).\n
+            ! Without additional colors, it will loop over the default colors !"""
         )
 
     for idx, size in enumerate(sizes):

--- a/stitching/seam_finder.py
+++ b/stitching/seam_finder.py
@@ -5,6 +5,8 @@ import numpy as np
 
 from .blender import Blender
 
+import warnings
+from .stitching_error import StitchingWarning
 
 class SeamFinder:
     """https://docs.opencv.org/4.x/d7/d09/classcv_1_1detail_1_1SeamFinder.html"""
@@ -75,15 +77,15 @@ class SeamFinder:
         corners,
         sizes,
         colors=(
-            (255, 000, 000),
-            (000, 000, 255),
-            (000, 255, 000),
-            (000, 255, 255),
-            (255, 000, 255),
-            (128, 128, 255),
-            (128, 128, 128),
-            (000, 000, 128),
-            (000, 128, 255),
+            (255, 000, 000), # Red
+            (000, 000, 255), # Blue
+            (000, 255, 000), # Green
+            (000, 255, 255), # Yellow
+            (255, 000, 255), # Purple
+            (128, 128, 255), # Pink
+            (128, 128, 128), # Gray
+            (000, 000, 128), # Dark Blue
+            (000, 128, 255), # Light Blue
         ),
     ):
         imgs = colored_img_generator(sizes, colors)
@@ -94,24 +96,17 @@ class SeamFinder:
 
 
 def colored_img_generator(sizes, colors):
-    if type(colors) is not tuple:
-        raise ValueError(
-            "colors must be a tuple ! (like colors=((255, 000, 000), (000, 255, 255))."
-        )
 
     if len(sizes) + 1 > len(colors):
-        print(
-            """! WARNING : Not enough default colors !\n
-            Please add additional colors in a tuple.\n
-            Example of use : colors=((255, 000, 000), (000, 255, 255)).\n
-            ! Without additional colors, it will loop over the default colors !"""
-        )
+        warnings.warn(
+            """Without additional colors, there will be seam masks with identical colors""",
+            StitchingWarning)
 
     for idx, size in enumerate(sizes):
         yield create_img_by_size(size, colors[idx % len(colors)])
 
 
-def create_img_by_size(size, color):
+def create_img_by_size(size, color=(0, 0, 0)):
     width, height = size
     img = np.zeros((height, width, 3), np.uint8)
     img[:] = color

--- a/stitching/seam_finder.py
+++ b/stitching/seam_finder.py
@@ -70,33 +70,28 @@ class SeamFinder:
         return cv.dilate(seam_lines, kernel)
 
     @staticmethod
-    def blend_seam_masks(seam_masks, corners, sizes):
-        imgs = colored_img_generator(sizes)
+    def blend_seam_masks(seam_masks, corners, sizes, colors=((255, 000, 000), (000, 000, 255), (000, 255, 000), (000, 255, 255), (255, 000, 255), (128, 128, 255), (128, 128, 128), (000, 000, 128), (000, 128, 255))):
+        imgs = colored_img_generator(sizes, colors)
         blended_seam_masks, _ = Blender.create_panorama(
             imgs, seam_masks, corners, sizes
         )
         return blended_seam_masks
 
 
-def colored_img_generator(
-    sizes,
-    colors=(
-        (255, 000, 000),  # Blue
-        (000, 000, 255),  # Red
-        (000, 255, 000),  # Green
-        (000, 255, 255),  # Yellow
-        (255, 000, 255),  # Magenta
-        (128, 128, 255),  # Pink
-        (128, 128, 128),  # Gray
-        (000, 000, 128),  # Brown
-        (000, 128, 255),
-    ),  # Orange
-):
+def colored_img_generator(sizes, colors):
+    if type(colors) is not tuple:
+        raise ValueError("colors must be a tuple ! (like colors=((255, 000, 000), (000, 255, 255)).")
+
+    if len(sizes) + 1 > len(colors):
+        print('''WARNING : Not enough default colors !\n
+        Please add additional colors in a tuple. (like colors=((255, 000, 000), (000, 255, 255)).\n
+        Without additional colors, the program will loop over the default colors.''')
+
     for idx, size in enumerate(sizes):
-        yield create_img_by_size(size, colors[idx % len(colors)])
+        yield create_img_by_size(size, colors[idx%len(colors)])
 
 
-def create_img_by_size(size, color=(0, 0, 0)):
+def create_img_by_size(size, color):
     width, height = size
     img = np.zeros((height, width, 3), np.uint8)
     img[:] = color

--- a/stitching/seam_finder.py
+++ b/stitching/seam_finder.py
@@ -1,12 +1,12 @@
+import warnings
 from collections import OrderedDict
 
 import cv2 as cv
 import numpy as np
 
 from .blender import Blender
-
-import warnings
 from .stitching_error import StitchingWarning
+
 
 class SeamFinder:
     """https://docs.opencv.org/4.x/d7/d09/classcv_1_1detail_1_1SeamFinder.html"""
@@ -77,15 +77,15 @@ class SeamFinder:
         corners,
         sizes,
         colors=(
-            (255, 000, 000), # Red
-            (000, 000, 255), # Blue
-            (000, 255, 000), # Green
-            (000, 255, 255), # Yellow
-            (255, 000, 255), # Purple
-            (128, 128, 255), # Pink
-            (128, 128, 128), # Gray
-            (000, 000, 128), # Dark Blue
-            (000, 128, 255), # Light Blue
+            (255, 000, 000),  # Red
+            (000, 000, 255),  # Blue
+            (000, 255, 000),  # Green
+            (000, 255, 255),  # Yellow
+            (255, 000, 255),  # Purple
+            (128, 128, 255),  # Pink
+            (128, 128, 128),  # Gray
+            (000, 000, 128),  # Dark Blue
+            (000, 128, 255),  # Light Blue
         ),
     ):
         imgs = colored_img_generator(sizes, colors)
@@ -96,11 +96,11 @@ class SeamFinder:
 
 
 def colored_img_generator(sizes, colors):
-
     if len(sizes) + 1 > len(colors):
         warnings.warn(
             """Without additional colors, there will be seam masks with identical colors""",
-            StitchingWarning)
+            StitchingWarning,
+        )
 
     for idx, size in enumerate(sizes):
         yield create_img_by_size(size, colors[idx % len(colors)])

--- a/stitching/seam_finder.py
+++ b/stitching/seam_finder.py
@@ -70,7 +70,22 @@ class SeamFinder:
         return cv.dilate(seam_lines, kernel)
 
     @staticmethod
-    def blend_seam_masks(seam_masks, corners, sizes, colors=((255, 000, 000), (000, 000, 255), (000, 255, 000), (000, 255, 255), (255, 000, 255), (128, 128, 255), (128, 128, 128), (000, 000, 128), (000, 128, 255))):
+    def blend_seam_masks(
+        seam_masks,
+        corners,
+        sizes,
+        colors=(
+            (255, 000, 000),
+            (000, 000, 255),
+            (000, 255, 000),
+            (000, 255, 255),
+            (255, 000, 255),
+            (128, 128, 255),
+            (128, 128, 128),
+            (000, 000, 128),
+            (000, 128, 255),
+        ),
+    ):
         imgs = colored_img_generator(sizes, colors)
         blended_seam_masks, _ = Blender.create_panorama(
             imgs, seam_masks, corners, sizes
@@ -80,15 +95,19 @@ class SeamFinder:
 
 def colored_img_generator(sizes, colors):
     if type(colors) is not tuple:
-        raise ValueError("colors must be a tuple ! (like colors=((255, 000, 000), (000, 255, 255)).")
+        raise ValueError(
+            "colors must be a tuple ! (like colors=((255, 000, 000), (000, 255, 255))."
+        )
 
     if len(sizes) + 1 > len(colors):
-        print('''WARNING : Not enough default colors !\n
+        print(
+            """WARNING : Not enough default colors !\n
         Please add additional colors in a tuple. (like colors=((255, 000, 000), (000, 255, 255)).\n
-        Without additional colors, the program will loop over the default colors.''')
+        Without additional colors, the program will loop over the default colors."""
+        )
 
     for idx, size in enumerate(sizes):
-        yield create_img_by_size(size, colors[idx%len(colors)])
+        yield create_img_by_size(size, colors[idx % len(colors)])
 
 
 def create_img_by_size(size, color):

--- a/stitching/seam_finder.py
+++ b/stitching/seam_finder.py
@@ -93,12 +93,7 @@ def colored_img_generator(
     ),  # Orange
 ):
     for idx, size in enumerate(sizes):
-        if idx + 1 > len(colors):
-            raise ValueError(
-                "Not enough default colors! Pass additional "
-                'colors to "colors" parameter'
-            )
-        yield create_img_by_size(size, colors[idx])
+        yield create_img_by_size(size, colors[idx%len(colors)])
 
 
 def create_img_by_size(size, color=(0, 0, 0)):


### PR DESCRIPTION
Before this correction, the function raised "ValueError("Not enough default colors! Pass additional " 'colors to "colors" parameter')", but we couldn't pass additional colors.

To avoid this problem and to make it easier, the correction takes the 9 known colors (Blue, Red, Green, Yellow, Magenta, Pink, Gray, Brown, Orange), and loop over them if needed.