### PR TITLE
Add masking for feature detection

### DIFF
--- a/stitching/cli/stitch.py
+++ b/stitching/cli/stitch.py
@@ -61,6 +61,13 @@ def create_parser():
         type=int,
     )
     parser.add_argument(
+        "--masks",
+        nargs="*",
+        default=[],
+        help="Masks for selecting where features should be detected.",
+        type=str,
+    )
+    parser.add_argument(
         "--matcher_type",
         action="store",
         default=FeatureMatcher.DEFAULT_MATCHER,
@@ -272,6 +279,7 @@ def main():
     preview = args_dict.pop("preview")
     output = args_dict.pop("output")
     print("stitching " + " ".join(img_names) + " into " + output)
+    mask_names = args_dict.pop("masks")
 
     # Create Stitcher
     affine_mode = args_dict.pop("affine")
@@ -281,7 +289,7 @@ def main():
     else:
         stitcher = Stitcher(**args_dict)
 
-    panorama = stitcher.stitch(img_names)
+    panorama = stitcher.stitch(img_names, mask_names)
 
     cv.imwrite(output, panorama)
 

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 from .context import FeatureDetector, load_test_img
 
 
@@ -16,6 +18,26 @@ class TestFeatureDetector(unittest.TestCase):
         detector = FeatureDetector("orb", nfeatures=other_keypoints)
         features = detector.detect_features(img1)
         self.assertEqual(len(features.getKeypoints()), other_keypoints)
+
+    def test_feature_masking(self):
+        img1 = load_test_img("s1.jpg")
+
+        # creating the image mask and setting only the middle 20% as enabled
+        height, width = img1.shape[:2]
+        top, bottom, left, right = map(
+            int, (0.4 * height, 0.6 * height, 0.4 * width, 0.6 * width)
+        )
+        mask = np.zeros(shape=(height, width), dtype=np.uint8)
+        mask[top:bottom, left:right] = 255
+
+        num_features = 1000
+        detector = FeatureDetector("orb", nfeatures=num_features)
+        keypoints = detector.detect_features(img1, mask=mask).getKeypoints()
+        self.assertTrue(len(keypoints) > 0)
+        for point in keypoints:
+            x, y = point.pt
+            self.assertTrue(left <= x < right)
+            self.assertTrue(top <= y < bottom)
 
 
 def start_test():


### PR DESCRIPTION
I created this PR as a follow-up for [PR#55](https://github.com/OpenStitching/stitching/pull/55) since no further progress has been made. I based my implementation on @piercus's attempt, so he receives partial credit.

I only implemented the first part of the above PR (feature masking, not background stitching etc.). But I think this is already very helpful for stitching.

This PR adds:
- The `--masks` cli parameter (as mentioned, only feature masks for now)
- Change to the `ImageHandler` to allow storing mask file names, as well as corresponding accessors
- An additional test for feature masking in `test_detector.py`