### PR TITLE
Fix typo in testing method

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -36,7 +36,7 @@ IN_DIR = os.path.join(TEST_DIR, "testdata")
 OUT_DIR = os.path.join(TEST_DIR, "results")
 
 
-def load_testimg(img_name):
+def load_testing(img_name):
     return cv.imread(testinput(img_name))
 
 

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,11 +1,11 @@
 import unittest
 
-from .context import FeatureDetector, load_testimg
+from .context import FeatureDetector, load_testing
 
 
 class TestFeatureDetector(unittest.TestCase):
     def test_number_of_keypoints(self):
-        img1 = load_testimg("s1.jpg")
+        img1 = load_testing("s1.jpg")
 
         default_number_of_keypoints = 500
         detector = FeatureDetector("orb")

--- a/tests/test_range_width_matcher.py
+++ b/tests/test_range_width_matcher.py
@@ -6,7 +6,7 @@ from .context import (
     FeatureDetector,
     FeatureMatcher,
     Stitcher,
-    load_testimg,
+    load_testing,
     testinput,
     testoutput,
 )
@@ -14,9 +14,9 @@ from .context import (
 
 class TestRangeMatcher(unittest.TestCase):
     def test_BestOf2NearestRangeMatcher(self):
-        img1 = load_testimg("weir_1.jpg")
-        img2 = load_testimg("weir_2.jpg")
-        img3 = load_testimg("weir_3.jpg")
+        img1 = load_testing("weir_1.jpg")
+        img2 = load_testing("weir_2.jpg")
+        img3 = load_testing("weir_3.jpg")
 
         detector = FeatureDetector("orb")
         features = [detector.detect_features(img) for img in [img1, img2, img3]]

--- a/tests/test_timelapse.py
+++ b/tests/test_timelapse.py
@@ -3,7 +3,7 @@ import unittest
 import cv2 as cv
 import numpy as np
 
-from .context import Stitcher, load_testimg, testinput
+from .context import Stitcher, load_testing, testinput
 
 
 class TestImageComposition(unittest.TestCase):
@@ -14,7 +14,7 @@ class TestImageComposition(unittest.TestCase):
             crop=False,
         )
         _ = stitcher.stitch([testinput("s?.jpg")])
-        frame1 = load_testimg("timelapse_s1.jpg")
+        frame1 = load_testing("timelapse_s1.jpg")
 
         max_image_shape_derivation = 3
         np.testing.assert_allclose(


### PR DESCRIPTION
Fixes typo in `load_testing` method for loading images in unit tests.