### PR TITLE
More consistent naming of test methods

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -36,17 +36,17 @@ IN_DIR = os.path.join(TEST_DIR, "testdata")
 OUT_DIR = os.path.join(TEST_DIR, "results")
 
 
-def load_testimg(img_name):
-    return cv.imread(testinput(img_name))
+def load_test_img(img_name):
+    return cv.imread(test_input(img_name))
 
 
-def testinput(file):
+def test_input(file):
     return os.path.join(IN_DIR, file)
 
 
-def write_testresult(img_name, img):
-    cv.imwrite(testoutput(img_name), img)
+def write_test_result(img_name, img):
+    cv.imwrite(test_output(img_name), img)
 
 
-def testoutput(file):
+def test_output(file):
     return os.path.join(OUT_DIR, file)

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,11 +1,11 @@
 import unittest
 
-from .context import FeatureDetector, load_testimg
+from .context import FeatureDetector, load_test_img
 
 
 class TestFeatureDetector(unittest.TestCase):
     def test_number_of_keypoints(self):
-        img1 = load_testimg("s1.jpg")
+        img1 = load_test_img("s1.jpg")
 
         default_number_of_keypoints = 500
         detector = FeatureDetector("orb")
@@ -18,9 +18,9 @@ class TestFeatureDetector(unittest.TestCase):
         self.assertEqual(len(features.getKeypoints()), other_keypoints)
 
 
-def starttest():
+def start_test():
     unittest.main()
 
 
 if __name__ == "__main__":
-    starttest()
+    start_test()

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -32,9 +32,9 @@ class TestMatcher(unittest.TestCase):
         self.assertEqual(implicit_match_conf_other, 0.65)
 
 
-def starttest():
+def start_test():
     unittest.main()
 
 
 if __name__ == "__main__":
-    starttest()
+    start_test()

--- a/tests/test_megapix_scaler.py
+++ b/tests/test_megapix_scaler.py
@@ -39,9 +39,9 @@ class TestScaler(unittest.TestCase):
         self.assertEqual(downscaler.scale, 1.0)
 
 
-def starttest():
+def start_test():
     unittest.main()
 
 
 if __name__ == "__main__":
-    starttest()
+    start_test()

--- a/tests/test_range_width_matcher.py
+++ b/tests/test_range_width_matcher.py
@@ -42,7 +42,11 @@ class TestRangeMatcher(unittest.TestCase):
         }
         stitcher = Stitcher(**settings)
         stitcher.stitch(
-            [test_input("weir_1.jpg"), test_input("weir_2.jpg"), test_input("weir_3.jpg")]
+            [
+                test_input("weir_1.jpg"),
+                test_input("weir_2.jpg"),
+                test_input("weir_3.jpg"),
+            ]
         )
 
         # TODO: Automated test that matches graph is correct

--- a/tests/test_range_width_matcher.py
+++ b/tests/test_range_width_matcher.py
@@ -6,17 +6,17 @@ from .context import (
     FeatureDetector,
     FeatureMatcher,
     Stitcher,
-    load_testimg,
-    testinput,
-    testoutput,
+    load_test_img,
+    test_input,
+    test_output,
 )
 
 
 class TestRangeMatcher(unittest.TestCase):
     def test_BestOf2NearestRangeMatcher(self):
-        img1 = load_testimg("weir_1.jpg")
-        img2 = load_testimg("weir_2.jpg")
-        img3 = load_testimg("weir_3.jpg")
+        img1 = load_test_img("weir_1.jpg")
+        img2 = load_test_img("weir_2.jpg")
+        img3 = load_test_img("weir_3.jpg")
 
         detector = FeatureDetector("orb")
         features = [detector.detect_features(img) for img in [img1, img2, img3]]
@@ -38,11 +38,11 @@ class TestRangeMatcher(unittest.TestCase):
         settings = {
             "range_width": 1,
             "confidence_threshold": 0,
-            "matches_graph_dot_file": testoutput("range_width_matches_graph.txt"),
+            "matches_graph_dot_file": test_output("range_width_matches_graph.txt"),
         }
         stitcher = Stitcher(**settings)
         stitcher.stitch(
-            [testinput("weir_1.jpg"), testinput("weir_2.jpg"), testinput("weir_3.jpg")]
+            [test_input("weir_1.jpg"), test_input("weir_2.jpg"), test_input("weir_3.jpg")]
         )
 
         # TODO: Automated test that matches graph is correct

--- a/tests/test_stitch_cli.py
+++ b/tests/test_stitch_cli.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import cv2 as cv
 import numpy as np
 
-from .context import create_parser, main, testinput, testoutput
+from .context import create_parser, main, test_input, test_output
 
 
 class TestCLI(unittest.TestCase):
@@ -17,16 +17,16 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(parsed.low_megapix, 1.0)
 
     def test_main(self):
-        output = testoutput("weir_from_cli.jpg")
-        testargs = [
+        output = test_output("weir_from_cli.jpg")
+        test_args = [
             "stitch.py",
-            testinput("weir_?.jpg"),
+            test_input("weir_?.jpg"),
             "--final_megapix",
             "0.05",
             "--output",
             output,
         ]
-        with patch.object(sys, "argv", testargs):
+        with patch.object(sys, "argv", test_args):
             main()
 
             img = cv.imread(output)
@@ -36,9 +36,9 @@ class TestCLI(unittest.TestCase):
             )
 
 
-def starttest():
+def start_test():
     unittest.main()
 
 
 if __name__ == "__main__":
-    starttest()
+    start_test()

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -7,9 +7,9 @@ from .context import (
     Stitcher,
     StitchingError,
     StitchingWarning,
-    testinput,
-    testoutput,
-    write_testresult,
+    test_input,
+    test_output,
+    write_test_result,
 )
 
 
@@ -17,15 +17,15 @@ class TestStitcher(unittest.TestCase):
     def test_stitcher_with_not_matching_images(self):
         stitcher = Stitcher()
         with self.assertRaises(StitchingError) as cm:
-            stitcher.stitch([testinput("s1.jpg"), testinput("boat1.jpg")])
+            stitcher.stitch([test_input("s1.jpg"), test_input("boat1.jpg")])
         self.assertTrue(
             "No match exceeds the given confidence threshold" in str(cm.exception)
         )
 
     def test_stitcher_aquaduct(self):
         stitcher = Stitcher(nfeatures=250, crop=False)
-        result = stitcher.stitch([testinput("s?.jpg")])
-        write_testresult("s_result.jpg", result)
+        result = stitcher.stitch([test_input("s?.jpg")])
+        write_test_result("s_result.jpg", result)
 
         max_image_shape_derivation = 3
         np.testing.assert_allclose(
@@ -44,16 +44,16 @@ class TestStitcher(unittest.TestCase):
         stitcher = Stitcher(**settings)
         result = stitcher.stitch(
             [
-                testinput("boat5.jpg"),
-                testinput("boat2.jpg"),
-                testinput("boat3.jpg"),
-                testinput("boat4.jpg"),
-                testinput("boat1.jpg"),
-                testinput("boat6.jpg"),
+                test_input("boat5.jpg"),
+                test_input("boat2.jpg"),
+                test_input("boat3.jpg"),
+                test_input("boat4.jpg"),
+                test_input("boat1.jpg"),
+                test_input("boat6.jpg"),
             ]
         )
 
-        write_testresult("boat_fisheye.jpg", result)
+        write_test_result("boat_fisheye.jpg", result)
 
         max_image_shape_derivation = 600
         np.testing.assert_allclose(
@@ -71,16 +71,16 @@ class TestStitcher(unittest.TestCase):
         stitcher = Stitcher(**settings)
         result = stitcher.stitch(
             [
-                testinput("boat5.jpg"),
-                testinput("boat2.jpg"),
-                testinput("boat3.jpg"),
-                testinput("boat4.jpg"),
-                testinput("boat1.jpg"),
-                testinput("boat6.jpg"),
+                test_input("boat5.jpg"),
+                test_input("boat2.jpg"),
+                test_input("boat3.jpg"),
+                test_input("boat4.jpg"),
+                test_input("boat1.jpg"),
+                test_input("boat6.jpg"),
             ]
         )
 
-        write_testresult("boat_plane.jpg", result)
+        write_test_result("boat_plane.jpg", result)
 
         max_image_shape_derivation = 600
         np.testing.assert_allclose(
@@ -88,7 +88,7 @@ class TestStitcher(unittest.TestCase):
         )
 
     def test_stitcher_boat_aquaduct_subset(self):
-        graph = testoutput("boat_subset_matches_graph.txt")
+        graph = test_output("boat_subset_matches_graph.txt")
         settings = {"final_megapix": 1, "matches_graph_dot_file": graph}
 
         stitcher = Stitcher(**settings)
@@ -96,20 +96,20 @@ class TestStitcher(unittest.TestCase):
         with self.assertWarns(StitchingWarning) as cm:
             result = stitcher.stitch(
                 [
-                    testinput("boat5.jpg"),
-                    testinput("s1.jpg"),
-                    testinput("s2.jpg"),
-                    testinput("boat2.jpg"),
-                    testinput("boat3.jpg"),
-                    testinput("boat4.jpg"),
-                    testinput("boat1.jpg"),
-                    testinput("boat6.jpg"),
+                    test_input("boat5.jpg"),
+                    test_input("s1.jpg"),
+                    test_input("s2.jpg"),
+                    test_input("boat2.jpg"),
+                    test_input("boat3.jpg"),
+                    test_input("boat4.jpg"),
+                    test_input("boat1.jpg"),
+                    test_input("boat6.jpg"),
                 ]
             )
 
         self.assertTrue(str(cm.warning).startswith("Not all images are included"))
 
-        write_testresult("boat_subset_low_res.jpg", result)
+        write_test_result("boat_subset_low_res.jpg", result)
 
         max_image_shape_derivation = 100
         np.testing.assert_allclose(
@@ -127,9 +127,9 @@ class TestStitcher(unittest.TestCase):
         }
 
         stitcher = AffineStitcher(**settings)
-        result = stitcher.stitch([testinput("budapest?.jpg")])
+        result = stitcher.stitch([test_input("budapest?.jpg")])
 
-        write_testresult("budapest.jpg", result)
+        write_test_result("budapest.jpg", result)
 
         max_image_shape_derivation = 50
         np.testing.assert_allclose(
@@ -137,9 +137,9 @@ class TestStitcher(unittest.TestCase):
         )
 
 
-def starttest():
+def start_test():
     unittest.main()
 
 
 if __name__ == "__main__":
-    starttest()
+    start_test()

--- a/tests/test_timelapse.py
+++ b/tests/test_timelapse.py
@@ -3,18 +3,18 @@ import unittest
 import cv2 as cv
 import numpy as np
 
-from .context import Stitcher, load_testimg, testinput
+from .context import Stitcher, load_test_img, test_input
 
 
 class TestImageComposition(unittest.TestCase):
     def test_timelapse(self):
         stitcher = Stitcher(
             timelapse="as_is",
-            timelapse_prefix=testinput("timelapse_"),
+            timelapse_prefix=test_input("timelapse_"),
             crop=False,
         )
-        _ = stitcher.stitch([testinput("s?.jpg")])
-        frame1 = load_testimg("timelapse_s1.jpg")
+        _ = stitcher.stitch([test_input("s?.jpg")])
+        frame1 = load_test_img("timelapse_s1.jpg")
 
         max_image_shape_derivation = 3
         np.testing.assert_allclose(
@@ -40,9 +40,9 @@ class TestImageComposition(unittest.TestCase):
         self.assertEqual(cv.countNonZero(right), 0)
 
 
-def starttest():
+def start_test():
     unittest.main()
 
 
 if __name__ == "__main__":
-    starttest()
+    start_test()


### PR DESCRIPTION
I converted method names in `tests` to snake_case to follow common Python styling.
This probably avoids confusion as it did in [PR#105](https://github.com/OpenStitching/stitching/pull/105).