### PR TITLE
Add error codes to StitchingError

### DIFF
--- a/stitching/camera_adjuster.py
+++ b/stitching/camera_adjuster.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import cv2 as cv
 import numpy as np
 
-from .stitching_error import StitchingError
+from .stitching_error import CameraAdjustmentError
 
 
 class CameraAdjuster:
@@ -45,6 +45,6 @@ class CameraAdjuster:
     def adjust(self, features, pairwise_matches, estimated_cameras):
         b, cameras = self.adjuster.apply(features, pairwise_matches, estimated_cameras)
         if not b:
-            raise StitchingError("Camera parameters adjusting failed.")
+            raise CameraAdjustmentError("Camera parameters adjusting failed.")
 
         return cameras

--- a/stitching/camera_estimator.py
+++ b/stitching/camera_estimator.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import cv2 as cv
 import numpy as np
 
-from .stitching_error import StitchingError
+from .stitching_error import HomographyEstimationError
 
 
 class CameraEstimator:
@@ -21,7 +21,7 @@ class CameraEstimator:
     def estimate(self, features, pairwise_matches):
         b, cameras = self.estimator.apply(features, pairwise_matches, None)
         if not b:
-            raise StitchingError("Homography estimation failed.")
+            raise HomographyEstimationError("Homography estimation failed.")
         for cam in cameras:
             cam.R = cam.R.astype(np.float32)
         return cameras

--- a/stitching/cropper.py
+++ b/stitching/cropper.py
@@ -4,7 +4,7 @@ import cv2 as cv
 import numpy as np
 
 from .blender import Blender
-from .stitching_error import StitchingError
+from .stitching_error import InvalidContourError, RectanglesNotOverlapError
 
 
 class Rectangle(namedtuple("Rectangle", "x y width height")):
@@ -94,7 +94,7 @@ class Cropper:
 
         contours, hierarchy = cv.findContours(mask, cv.RETR_TREE, cv.CHAIN_APPROX_NONE)
         if not hierarchy.shape == (1, 1, 4) or not np.all(hierarchy == -1):
-            raise StitchingError(
+            raise InvalidContourError(
                 """Invalid Contour. Run with --no-crop (using the stitch interface),
                                  crop=false (using the stitcher class) or Cropper(False)
                                  (using the cropper class)"""
@@ -130,7 +130,7 @@ class Cropper:
         x2 = min(rectangle1.x2, rectangle2.x2)
         y2 = min(rectangle1.y2, rectangle2.y2)
         if x2 < x1 or y2 < y1:
-            raise StitchingError("Rectangles do not overlap!")
+            raise RectanglesNotOverlapError("Rectangles do not overlap!")
         return Rectangle(x1, y1, x2 - x1, y2 - y1)
 
     @staticmethod

--- a/stitching/image_handler.py
+++ b/stitching/image_handler.py
@@ -3,7 +3,11 @@ import glob
 import cv2 as cv
 
 from .megapix_scaler import MegapixDownscaler
-from .stitching_error import ResolutionMismatchError, InsufficientImagesError, ImageReadError
+from .stitching_error import (
+    ImageReadError,
+    InsufficientImagesError,
+    ResolutionMismatchError,
+)
 
 
 class ImageHandler:

--- a/stitching/image_handler.py
+++ b/stitching/image_handler.py
@@ -3,7 +3,7 @@ import glob
 import cv2 as cv
 
 from .megapix_scaler import MegapixDownscaler
-from .stitching_error import StitchingError
+from .stitching_error import ResolutionMismatchError, InsufficientImagesError, ImageReadError
 
 
 class ImageHandler:
@@ -18,7 +18,7 @@ class ImageHandler:
         final_megapix=DEFAULT_FINAL_MEGAPIX,
     ):
         if medium_megapix < low_megapix:
-            raise StitchingError(
+            raise ResolutionMismatchError(
                 "Medium resolution megapix need to be "
                 "greater or equal than low resolution "
                 "megapix"
@@ -36,7 +36,7 @@ class ImageHandler:
         if len(img_names) == 1:
             img_names = glob.glob(img_names[0])
         if len(img_names) < 2:
-            raise StitchingError("2 or more Images needed for Stitching")
+            raise InsufficientImagesError("2 or more Images needed for Stitching")
         self.img_names = img_names
 
     def resize_to_medium_resolution(self):
@@ -81,7 +81,7 @@ class ImageHandler:
     def read_image(img_name):
         img = cv.imread(img_name)
         if img is None:
-            raise StitchingError("Cannot read image " + img_name)
+            raise ImageReadError("Cannot read image " + img_name)
         return img
 
     def set_scaler_scales(self):

--- a/stitching/seam_finder.py
+++ b/stitching/seam_finder.py
@@ -5,7 +5,7 @@ import cv2 as cv
 import numpy as np
 
 from .blender import Blender
-from .stitching_error import StitchingWarning
+from .stitching_warning import StitchingWarning
 
 
 class SeamFinder:

--- a/stitching/seam_finder.py
+++ b/stitching/seam_finder.py
@@ -5,7 +5,7 @@ import cv2 as cv
 import numpy as np
 
 from .blender import Blender
-from .stitching_warning import StitchingWarning
+from .stitching_warning import IdenticalColorsWarning
 
 
 class SeamFinder:
@@ -100,7 +100,7 @@ def colored_img_generator(sizes, colors):
         warnings.warn(
             """Without additional colors,
             there will be seam masks with identical colors""",
-            StitchingWarning,
+            IdenticalColorsWarning,
         )
 
     for idx, size in enumerate(sizes):

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -10,7 +10,8 @@ from .feature_detector import FeatureDetector
 from .feature_matcher import FeatureMatcher
 from .image_handler import ImageHandler
 from .seam_finder import SeamFinder
-from .stitching_error import StitchingError
+from .stitching_error import *
+from .stitching_warning import *
 from .subsetter import Subsetter
 from .timelapser import Timelapser
 from .warper import Warper
@@ -219,7 +220,7 @@ class Stitcher:
         elif idx == self.mask_index:
             return self.mask
         else:
-            raise StitchingError("Invalid Mask Index!")
+            raise InvalidMaskIndexError("Invalid Mask Index!")
 
     def initialize_composition(self, corners, sizes):
         if self.timelapser.do_timelapse:
@@ -244,7 +245,7 @@ class Stitcher:
     def validate_kwargs(self, kwargs):
         for arg in kwargs:
             if arg not in self.DEFAULT_SETTINGS:
-                raise StitchingError("Invalid Argument: " + arg)
+                raise InvalidArgumentError("Invalid Argument: " + arg)
 
 
 class AffineStitcher(Stitcher):

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -10,7 +10,7 @@ from .feature_detector import FeatureDetector
 from .feature_matcher import FeatureMatcher
 from .image_handler import ImageHandler
 from .seam_finder import SeamFinder
-from .stitching_error import InvalidMaskIndexError, InvalidArgumentError
+from .stitching_error import InvalidArgumentError, InvalidMaskIndexError
 from .subsetter import Subsetter
 from .timelapser import Timelapser
 from .warper import Warper

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -10,8 +10,7 @@ from .feature_detector import FeatureDetector
 from .feature_matcher import FeatureMatcher
 from .image_handler import ImageHandler
 from .seam_finder import SeamFinder
-from .stitching_error import *
-from .stitching_warning import *
+from .stitching_error import InvalidMaskIndexError, InvalidArgumentError
 from .subsetter import Subsetter
 from .timelapser import Timelapser
 from .warper import Warper

--- a/stitching/stitching_error.py
+++ b/stitching/stitching_error.py
@@ -1,2 +1,32 @@
 class StitchingError(Exception):
     pass
+
+class CameraAdjustmentError(StitchingError):
+    pass
+
+class InvalidMaskIndexError(StitchingError):
+    pass
+
+class InvalidArgumentError(StitchingError):
+    pass
+
+class NoMatchExceedsThresholdError(StitchingError):
+    pass
+
+class HomographyEstimationError(StitchingError):
+    pass
+
+class InvalidContourError(StitchingError):
+    pass
+
+class RectanglesNotOverlapError(StitchingError):
+    pass
+
+class ResolutionMismatchError(StitchingError):
+    pass
+
+class InsufficientImagesError(StitchingError):
+    pass
+
+class ImageReadError(StitchingError):
+    pass

--- a/stitching/stitching_error.py
+++ b/stitching/stitching_error.py
@@ -1,32 +1,42 @@
 class StitchingError(Exception):
     pass
 
+
 class CameraAdjustmentError(StitchingError):
     pass
+
 
 class InvalidMaskIndexError(StitchingError):
     pass
 
+
 class InvalidArgumentError(StitchingError):
     pass
+
 
 class NoMatchExceedsThresholdError(StitchingError):
     pass
 
+
 class HomographyEstimationError(StitchingError):
     pass
+
 
 class InvalidContourError(StitchingError):
     pass
 
+
 class RectanglesNotOverlapError(StitchingError):
     pass
+
 
 class ResolutionMismatchError(StitchingError):
     pass
 
+
 class InsufficientImagesError(StitchingError):
     pass
+
 
 class ImageReadError(StitchingError):
     pass

--- a/stitching/stitching_error.py
+++ b/stitching/stitching_error.py
@@ -1,6 +1,2 @@
 class StitchingError(Exception):
     pass
-
-
-class StitchingWarning(UserWarning):
-    pass

--- a/stitching/stitching_warning.py
+++ b/stitching/stitching_warning.py
@@ -1,0 +1,2 @@
+class StitchingWarning(UserWarning):
+    pass

--- a/stitching/stitching_warning.py
+++ b/stitching/stitching_warning.py
@@ -1,8 +1,10 @@
 class StitchingWarning(UserWarning):
     pass
 
+
 class IdenticalColorsWarning(StitchingWarning):
     pass
+
 
 class ImagesNotFullIncludedWarning(StitchingWarning):
     pass

--- a/stitching/stitching_warning.py
+++ b/stitching/stitching_warning.py
@@ -1,2 +1,8 @@
 class StitchingWarning(UserWarning):
     pass
+
+class IdenticalColorsWarning(StitchingWarning):
+    pass
+
+class ImagesNotFullIncludedWarning(StitchingWarning):
+    pass

--- a/stitching/subsetter.py
+++ b/stitching/subsetter.py
@@ -5,7 +5,8 @@ import cv2 as cv
 import numpy as np
 
 from .feature_matcher import FeatureMatcher
-from .stitching_error import StitchingError, StitchingWarning
+from .stitching_error import StitchingError
+from .stitching_warning import StitchingWarning
 
 
 class Subsetter:

--- a/stitching/subsetter.py
+++ b/stitching/subsetter.py
@@ -5,8 +5,8 @@ import cv2 as cv
 import numpy as np
 
 from .feature_matcher import FeatureMatcher
-from .stitching_error import StitchingError
-from .stitching_warning import StitchingWarning
+from .stitching_error import NoMatchExceedsThresholdError
+from .stitching_warning import ImagesNotFullIncludedWarning
 
 
 class Subsetter:
@@ -36,7 +36,7 @@ class Subsetter:
                           parameter to analyze your matches. You might want to
                           lower the 'confidence_threshold' or try another 'detector'
                           to include all your images.""",
-                StitchingWarning,
+                ImagesNotFullIncludedWarning,
             )
 
         img_names = Subsetter.subset_list(img_names, indices)
@@ -67,7 +67,7 @@ class Subsetter:
         )
 
         if len(indices) < 2:
-            raise StitchingError(
+            raise NoMatchExceedsThresholdError(
                 """No match exceeds the given confidence threshold.
                                  Do your images have enough overlap and common
                                  features? If yes, you might want to lower the

--- a/tests/context.py
+++ b/tests/context.py
@@ -23,10 +23,8 @@ from stitching.megapix_scaler import (  # noqa: F401, E402
     MegapixScaler,
 )
 from stitching.seam_finder import SeamFinder  # noqa: F401, E402
-from stitching.stitching_error import (  # noqa: F401, E402
-    StitchingError,
-    StitchingWarning,
-)
+from stitching.stitching_error import StitchingError  # noqa: F401, E402
+from stitching.stitching_warning import StitchingWarning  # noqa: F401, E402
 from stitching.subsetter import Subsetter  # noqa: F401, E402
 from stitching.timelapser import Timelapser  # noqa: F401, E402
 from stitching.warper import Warper  # noqa: F401, E402

--- a/tests/context.py
+++ b/tests/context.py
@@ -23,8 +23,8 @@ from stitching.megapix_scaler import (  # noqa: F401, E402
     MegapixScaler,
 )
 from stitching.seam_finder import SeamFinder  # noqa: F401, E402
-from stitching.stitching_error import *  # noqa: F401, E402
-from stitching.stitching_warning import *  # noqa: F401, E402
+from stitching.stitching_error import NoMatchExceedsThresholdError  # noqa: F401, E402
+from stitching.stitching_warning import ImagesNotFullIncludedWarning  # noqa: F401, E402
 from stitching.subsetter import Subsetter  # noqa: F401, E402
 from stitching.timelapser import Timelapser  # noqa: F401, E402
 from stitching.warper import Warper  # noqa: F401, E402

--- a/tests/context.py
+++ b/tests/context.py
@@ -23,8 +23,8 @@ from stitching.megapix_scaler import (  # noqa: F401, E402
     MegapixScaler,
 )
 from stitching.seam_finder import SeamFinder  # noqa: F401, E402
-from stitching.stitching_error import StitchingError  # noqa: F401, E402
-from stitching.stitching_warning import StitchingWarning  # noqa: F401, E402
+from stitching.stitching_error import *  # noqa: F401, E402
+from stitching.stitching_warning import *  # noqa: F401, E402
 from stitching.subsetter import Subsetter  # noqa: F401, E402
 from stitching.timelapser import Timelapser  # noqa: F401, E402
 from stitching.warper import Warper  # noqa: F401, E402

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -4,9 +4,9 @@ import numpy as np
 
 from .context import (
     AffineStitcher,
-    Stitcher,
-    NoMatchExceedsThresholdError,
     ImagesNotFullIncludedWarning,
+    NoMatchExceedsThresholdError,
+    Stitcher,
     test_input,
     test_output,
     write_test_result,

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -5,8 +5,8 @@ import numpy as np
 from .context import (
     AffineStitcher,
     Stitcher,
-    StitchingError,
-    StitchingWarning,
+    NoMatchExceedsThresholdError,
+    ImagesNotFullIncludedWarning,
     test_input,
     test_output,
     write_test_result,
@@ -16,7 +16,7 @@ from .context import (
 class TestStitcher(unittest.TestCase):
     def test_stitcher_with_not_matching_images(self):
         stitcher = Stitcher()
-        with self.assertRaises(StitchingError) as cm:
+        with self.assertRaises(NoMatchExceedsThresholdError) as cm:
             stitcher.stitch([test_input("s1.jpg"), test_input("boat1.jpg")])
         self.assertTrue(
             "No match exceeds the given confidence threshold" in str(cm.exception)
@@ -93,7 +93,7 @@ class TestStitcher(unittest.TestCase):
 
         stitcher = Stitcher(**settings)
 
-        with self.assertWarns(StitchingWarning) as cm:
+        with self.assertWarns(ImagesNotFullIncludedWarning) as cm:
             result = stitcher.stitch(
                 [
                     test_input("boat5.jpg"),


### PR DESCRIPTION
I distinguish the error and warning in the program in detail, so that my program can accurately capture errors and warnings and give feedback to the user.

Even though I don't change anything, unittest still throws an error and I don't know why.

**This PR adds:**
Errors:
- CameraAdjustmentError
- InvalidMaskIndexError
- InvalidArgumentError
- NoMatchExceedsThresholdError
- HomographyEstimationError
- InvalidContourError
- RectanglesNotOverlapError
- ResolutionMismatchError
- InsufficientImagesError
- ImageReadError

Warnings:
- IdenticalColorsWarning
- ImagesNotFullIncludedWarning