### PR TITLE
fix TypeError if cv.detail.leaveBiggestComponent returns a nested list

### DIFF
--- a/stitching/subsetter.py
+++ b/stitching/subsetter.py
@@ -59,6 +59,9 @@ class Subsetter:
             features, pairwise_matches, self.confidence_threshold
         )
 
+        # see https://github.com/OpenStitching/stitching/issues/40
+        indices = indices.flatten()
+
         if len(indices) < 2:
             raise StitchingError(
                 """No match exceeds the given confidence threshold.


### PR DESCRIPTION
this doesn't fix the python bindings problem of https://github.com/opencv/opencv/issues/24078 but should be a good workaround