### PR TITLE
bump opencv-python to most recent version (use explicit version number)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-opencv-python==4.9.0
+opencv-python==4.9.0.80
 largestinteriorrectangle
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-opencv-python>=4.0.1
+opencv-python==4.9.0
 largestinteriorrectangle
 requests


### PR DESCRIPTION
I tried with https://github.com/OpenStitching/stitching/pull/197 that the versions stated in requirements.txt are updated regulary so in our unittest we explicitely test against the latest opencv version. I expected dependabot to update the versions but probably since there where no explicit versions specified it never suggested to do any updates. With the next opencv release I hope that there will be a automatic PR to update requirements.txt