### PR TITLE
Add support for passing parameters to imwrite()

### DIFF
--- a/stitching/cli/stitch.py
+++ b/stitching/cli/stitch.py
@@ -275,6 +275,21 @@ def create_parser():
         help="The default is 'result.jpg'",
         type=str,
     )
+    parser.add_argument(
+        "--output_params",
+        action="store",
+        default=[],
+        help="Flags that will be passed to OpenCV's imwrite() for saving the "
+        "final output image. This allows overriding default quality and "
+        "compression of the final image. It should be a series of integer "
+        "pairs representing imwrite() flags and values. For example, to "
+        " output an uncompressed TIFF image, use: '--output_params 259 1' "
+        "where 259 corresponds to the 'IMWRITE_TIFF_COMPRESSION' flag, and 1 "
+        "corresponds to a flag value of 'IMWRITE_TIFF_COMPRESSION_NONE'. See "
+        "OpenCV documentation for all available options.",
+        nargs="+",
+        type=int,
+    )
     return parser
 
 
@@ -294,6 +309,7 @@ def main():
     verbose_dir = args_dict.pop("verbose_dir")
     preview = args_dict.pop("preview")
     output = args_dict.pop("output")
+    output_params = args_dict.pop("output_params")
 
     # Create Stitcher
     affine_mode = args_dict.pop("affine")
@@ -310,7 +326,7 @@ def main():
     else:
         print("stitching " + " ".join(images) + " into " + output)
         panorama = stitcher.stitch(images, feature_masks)
-        cv.imwrite(output, panorama)
+        cv.imwrite(output, panorama, output_params)
 
     if preview:
         zoom_x = 600.0 / panorama.shape[1]


### PR DESCRIPTION
This adds a new CLI argument for passing parameters into OpenCV's `imwrite()` function.

This allows, among other things, to customize compression of the output image file. For example, currently a TIFF will always be output with LZW compression as a default. This allows exporting uncompressed TIFFs. JPEG quality can also be configured.

For the full list of `imwrite()` parameters, see: https://docs.opencv.org/4.10.0/d8/d6a/group__imgcodecs__flags.html

See related discussion for more detail: https://github.com/OpenStitching/stitching/discussions/224

Starting this as a "draft" pull request so that we can see if tests pass, and determine if anything else is necessary.