### PR TITLE
Fix --affine CLI parameter

### DIFF
--- a/stitching/cli/stitch.py
+++ b/stitching/cli/stitch.py
@@ -47,7 +47,7 @@ def create_parser():
         action="store_true",
         help="Overwrites multiple parameters to optimize the stitching for "
         "scans and images captured by specialized devices. The follwing parameters "
-        "are set: " + AffineStitcher.AFFINE_DEFAULTS,
+        "are set: " + str(AffineStitcher.AFFINE_DEFAULTS),
     )
     parser.add_argument(
         "--medium_megapix",

--- a/stitching/cli/stitch.py
+++ b/stitching/cli/stitch.py
@@ -315,6 +315,7 @@ def main():
     affine_mode = args_dict.pop("affine")
 
     if affine_mode:
+        args_dict.update(AffineStitcher.AFFINE_DEFAULTS)
         stitcher = AffineStitcher(**args_dict)
     else:
         stitcher = Stitcher(**args_dict)

--- a/stitching/cli/stitch.py
+++ b/stitching/cli/stitch.py
@@ -46,7 +46,8 @@ def create_parser():
         "--affine",
         action="store_true",
         help="Overwrites multiple parameters to optimize the stitching for "
-        "scans and images captured by specialized devices.",
+        "scans and images captured by specialized devices. The follwing parameters "
+        "are set: " + AffineStitcher.AFFINE_DEFAULTS,
     )
     parser.add_argument(
         "--medium_megapix",

--- a/stitching/cropper.py
+++ b/stitching/cropper.py
@@ -95,7 +95,7 @@ class Cropper:
         contours, hierarchy = cv.findContours(mask, cv.RETR_TREE, cv.CHAIN_APPROX_NONE)
         if not hierarchy.shape == (1, 1, 4) or not np.all(hierarchy == -1):
             raise StitchingError(
-                "Invalid Contour. Run with --no-crop (using the stitch interface), crop=false (using the stitcher class) or Cropper(False) (using the cropper class)"
+                "Invalid Contour. Run with --no-crop (using the stitch interface), crop=false (using the stitcher class) or Cropper(False) (using the cropper class)"  # noqa: E501
             )
         contour = contours[0][:, 0, :]
 

--- a/stitching/cropper.py
+++ b/stitching/cropper.py
@@ -94,11 +94,7 @@ class Cropper:
 
         contours, hierarchy = cv.findContours(mask, cv.RETR_TREE, cv.CHAIN_APPROX_NONE)
         if not hierarchy.shape == (1, 1, 4) or not np.all(hierarchy == -1):
-            raise StitchingError(
-                """Invalid Contour. Run with --no-crop (using the stitch interface),
-                                 crop=false (using the stitcher class) or Cropper(False)
-                                 (using the cropper class)"""
-            )
+            raise StitchingError("Invalid Contour. Run with --no-crop (using the stitch interface), crop=false (using the stitcher class) or Cropper(False) (using the cropper class)")
         contour = contours[0][:, 0, :]
 
         lir = largestinteriorrectangle.lir(mask > 0, contour)

--- a/stitching/cropper.py
+++ b/stitching/cropper.py
@@ -94,7 +94,9 @@ class Cropper:
 
         contours, hierarchy = cv.findContours(mask, cv.RETR_TREE, cv.CHAIN_APPROX_NONE)
         if not hierarchy.shape == (1, 1, 4) or not np.all(hierarchy == -1):
-            raise StitchingError("Invalid Contour. Run with --no-crop (using the stitch interface), crop=false (using the stitcher class) or Cropper(False) (using the cropper class)")
+            raise StitchingError(
+                "Invalid Contour. Run with --no-crop (using the stitch interface), crop=false (using the stitcher class) or Cropper(False) (using the cropper class)"
+            )
         contour = contours[0][:, 0, :]
 
         lir = largestinteriorrectangle.lir(mask > 0, contour)

--- a/stitching/seam_finder.py
+++ b/stitching/seam_finder.py
@@ -98,8 +98,7 @@ class SeamFinder:
 def colored_img_generator(sizes, colors):
     if len(sizes) + 1 > len(colors):
         warnings.warn(
-            """Without additional colors,
-            there will be seam masks with identical colors""",
+            "Without additional colors, there will be seam masks with identical colors",
             StitchingWarning,
         )
 

--- a/stitching/seam_finder.py
+++ b/stitching/seam_finder.py
@@ -98,7 +98,7 @@ class SeamFinder:
 def colored_img_generator(sizes, colors):
     if len(sizes) + 1 > len(colors):
         warnings.warn(
-            "Without additional colors, there will be seam masks with identical colors",
+            "Without additional colors, there will be seam masks with identical colors",  # noqa: E501
             StitchingWarning,
         )
 

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -281,7 +281,7 @@ class AffineStitcher(Stitcher):
         for key, value in kwargs.items():
             if key in self.AFFINE_DEFAULTS and value != self.AFFINE_DEFAULTS[key]:
                 warnings.warn(
-                    f"You are overwriting an affine default ({key}={self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make sure this is intended",
+                    f"You are overwriting an affine default ({key}={self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make sure this is intended",  # noqa: E501
                     StitchingWarning,
                 )
         super().initialize_stitcher(**kwargs)

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -282,7 +282,7 @@ class AffineStitcher(Stitcher):
             if key in self.AFFINE_DEFAULTS and value != self.AFFINE_DEFAULTS[key]:
                 warnings.warn(
                     f"""You are overwriting an affine default ({key}=
-                    {self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make 
+                    {self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make
                 sure this is intended""",
                     StitchingWarning,
                 )

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -281,7 +281,9 @@ class AffineStitcher(Stitcher):
         for key, value in kwargs.items():
             if key in self.AFFINE_DEFAULTS and value != self.AFFINE_DEFAULTS[key]:
                 warnings.warn(
-                    f"""You are overwriting an affine default ({key}={self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make sure this is intended""",
+                    f"""You are overwriting an affine default ({key}=
+                    {self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make 
+                sure this is intended""",
                     StitchingWarning,
                 )
         super().initialize_stitcher(**kwargs)

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+import warnings
 
 from .blender import Blender
 from .camera_adjuster import CameraAdjuster
@@ -10,7 +11,7 @@ from .feature_detector import FeatureDetector
 from .feature_matcher import FeatureMatcher
 from .images import Images
 from .seam_finder import SeamFinder
-from .stitching_error import StitchingError
+from .stitching_error import StitchingError, StitchingWarning
 from .subsetter import Subsetter
 from .timelapser import Timelapser
 from .verbose import verbose_stitching
@@ -275,3 +276,9 @@ class AffineStitcher(Stitcher):
 
     DEFAULT_SETTINGS = Stitcher.DEFAULT_SETTINGS.copy()
     DEFAULT_SETTINGS.update(AFFINE_DEFAULTS)
+
+    def initialize_stitcher(self, **kwargs):
+        for key, value in kwargs.items():
+            if key in self.AFFINE_DEFAULTS and value != self.AFFINE_DEFAULTS[key]:
+                warnings.warn(f"""You are overwriting an affine default ({key}={self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make sure this is intended""", StitchingWarning)        
+        super().initialize_stitcher(**kwargs)

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -280,10 +280,7 @@ class AffineStitcher(Stitcher):
     def initialize_stitcher(self, **kwargs):
         for key, value in kwargs.items():
             if key in self.AFFINE_DEFAULTS and value != self.AFFINE_DEFAULTS[key]:
-                warnings.warn(
-                    f"""You are overwriting an affine default ({key}=
-                    {self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make
-                sure this is intended""",
+                warnings.warn(f"You are overwriting an affine default ({key}={self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make sure this is intended",
                     StitchingWarning,
                 )
         super().initialize_stitcher(**kwargs)

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -280,7 +280,8 @@ class AffineStitcher(Stitcher):
     def initialize_stitcher(self, **kwargs):
         for key, value in kwargs.items():
             if key in self.AFFINE_DEFAULTS and value != self.AFFINE_DEFAULTS[key]:
-                warnings.warn(f"You are overwriting an affine default ({key}={self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make sure this is intended",
+                warnings.warn(
+                    f"You are overwriting an affine default ({key}={self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make sure this is intended",
                     StitchingWarning,
                 )
         super().initialize_stitcher(**kwargs)

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -1,5 +1,5 @@
-from types import SimpleNamespace
 import warnings
+from types import SimpleNamespace
 
 from .blender import Blender
 from .camera_adjuster import CameraAdjuster
@@ -280,5 +280,8 @@ class AffineStitcher(Stitcher):
     def initialize_stitcher(self, **kwargs):
         for key, value in kwargs.items():
             if key in self.AFFINE_DEFAULTS and value != self.AFFINE_DEFAULTS[key]:
-                warnings.warn(f"""You are overwriting an affine default ({key}={self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make sure this is intended""", StitchingWarning)        
+                warnings.warn(
+                    f"""You are overwriting an affine default ({key}={self.AFFINE_DEFAULTS[key]}) with another value ({value}). Make sure this is intended""",
+                    StitchingWarning,
+                )
         super().initialize_stitcher(**kwargs)

--- a/stitching/subsetter.py
+++ b/stitching/subsetter.py
@@ -30,7 +30,7 @@ class Subsetter:
 
         if len(indices) < len(img_names):
             warnings.warn(
-                "Not all images are included in the final panorama. If this is not intended, use the 'matches_graph_dot_file' parameter to analyze your matches. You might want to lower the 'confidence_threshold' or try another 'detector' to include all your images.",
+                "Not all images are included in the final panorama. If this is not intended, use the 'matches_graph_dot_file' parameter to analyze your matches. You might want to lower the 'confidence_threshold' or try another 'detector' to include all your images.",  # noqa: E501
                 StitchingWarning,
             )
 
@@ -62,7 +62,7 @@ class Subsetter:
 
         if len(indices) < 2:
             raise StitchingError(
-                "No match exceeds the given confidence threshold. Do your images have enough overlap and common features? If yes, you might want to lower the 'confidence_threshold' or try another 'detector'."
+                "No match exceeds the given confidence threshold. Do your images have enough overlap and common features? If yes, you might want to lower the 'confidence_threshold' or try another 'detector'."  # noqa: E501
             )
 
         return indices

--- a/stitching/subsetter.py
+++ b/stitching/subsetter.py
@@ -30,11 +30,7 @@ class Subsetter:
 
         if len(indices) < len(img_names):
             warnings.warn(
-                """Not all images are included in the final panorama.
-                          If this is not intended, use the 'matches_graph_dot_file'
-                          parameter to analyze your matches. You might want to
-                          lower the 'confidence_threshold' or try another 'detector'
-                          to include all your images.""",
+                "Not all images are included in the final panorama. If this is not intended, use the 'matches_graph_dot_file' parameter to analyze your matches. You might want to lower the 'confidence_threshold' or try another 'detector' to include all your images.",
                 StitchingWarning,
             )
 
@@ -65,13 +61,7 @@ class Subsetter:
         indices = indices.flatten()
 
         if len(indices) < 2:
-            raise StitchingError(
-                """No match exceeds the given confidence threshold.
-                                 Do your images have enough overlap and common
-                                 features? If yes, you might want to lower the
-                                 'confidence_threshold' or try another
-                                 'detector'."""
-            )
+            raise StitchingError("No match exceeds the given confidence threshold. Do your images have enough overlap and common features? If yes, you might want to lower the 'confidence_threshold' or try another 'detector'.")
 
         return indices
 

--- a/stitching/subsetter.py
+++ b/stitching/subsetter.py
@@ -61,7 +61,9 @@ class Subsetter:
         indices = indices.flatten()
 
         if len(indices) < 2:
-            raise StitchingError("No match exceeds the given confidence threshold. Do your images have enough overlap and common features? If yes, you might want to lower the 'confidence_threshold' or try another 'detector'.")
+            raise StitchingError(
+                "No match exceeds the given confidence threshold. Do your images have enough overlap and common features? If yes, you might want to lower the 'confidence_threshold' or try another 'detector'."
+            )
 
         return indices
 

--- a/tests/test_stitch_cli.py
+++ b/tests/test_stitch_cli.py
@@ -57,7 +57,7 @@ class TestCLI(unittest.TestCase):
             np.testing.assert_allclose(
                 img.shape[:2], (150, 590), atol=max_image_shape_derivation
             )
-            
+
     def test_main_affine(self):
         output = test_output("budapest_from_cli.jpg")
         test_args = [

--- a/tests/test_stitch_cli.py
+++ b/tests/test_stitch_cli.py
@@ -57,6 +57,27 @@ class TestCLI(unittest.TestCase):
             np.testing.assert_allclose(
                 img.shape[:2], (150, 590), atol=max_image_shape_derivation
             )
+            
+    def test_main_affine(self):
+        output = test_output("budapest_from_cli.jpg")
+        test_args = [
+            "stitch.py",
+            test_input("budapest?.jpg"),
+            "--affine",
+            "--detector",
+            "sift",
+            "--no-crop",
+            "--output",
+            output,
+        ]
+        with patch.object(sys, "argv", test_args):
+            main()
+
+            img = cv.imread(output)
+            max_image_shape_derivation = 50
+            np.testing.assert_allclose(
+                img.shape[:2], (1155, 2310), atol=max_image_shape_derivation
+            )
 
     def test_main_feature_masks(self):
         output = test_output("features_with_mask_from_cli.jpg")

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -164,7 +164,11 @@ class TestStitcher(unittest.TestCase):
     def test_affine_stitcher_warning(self):
         with self.assertWarns(StitchingWarning) as cm:
             AffineStitcher(estimator="homography")
-        self.assertTrue(str(cm.warning).startswith("""You are overwriting an affine default (estimator=affine) with another value (homography)"""))
+        self.assertTrue(
+            str(cm.warning).startswith(
+                """You are overwriting an affine default (estimator=affine) with another value (homography)"""
+            )
+        )
 
     def test_affine_stitcher_budapest(self):
         settings = {

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -166,8 +166,7 @@ class TestStitcher(unittest.TestCase):
             AffineStitcher(estimator="homography")
         self.assertTrue(
             str(cm.warning).startswith(
-                """You are overwriting an affine default (estimator=affine) with
-                another value (homography)"""
+                "You are overwriting an affine default (estimator=affine)"
             )
         )
 

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -161,6 +161,11 @@ class TestStitcher(unittest.TestCase):
             graph_content = file.read()
             self.assertTrue(graph_content.startswith("graph matches_graph{"))
 
+    def test_affine_stitcher_warning(self):
+        with self.assertWarns(StitchingWarning) as cm:
+            AffineStitcher(estimator="homography")
+        self.assertTrue(str(cm.warning).startswith("""You are overwriting an affine default (estimator=affine) with another value (homography)"""))
+
     def test_affine_stitcher_budapest(self):
         settings = {
             "detector": "sift",

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -166,7 +166,8 @@ class TestStitcher(unittest.TestCase):
             AffineStitcher(estimator="homography")
         self.assertTrue(
             str(cm.warning).startswith(
-                """You are overwriting an affine default (estimator=affine) with another value (homography)"""
+                """You are overwriting an affine default (estimator=affine) with 
+                another value (homography)"""
             )
         )
 

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -166,7 +166,7 @@ class TestStitcher(unittest.TestCase):
             AffineStitcher(estimator="homography")
         self.assertTrue(
             str(cm.warning).startswith(
-                """You are overwriting an affine default (estimator=affine) with 
+                """You are overwriting an affine default (estimator=affine) with
                 another value (homography)"""
             )
         )


### PR DESCRIPTION
This proposes a fix for #243

Here is the contents of `00_stitcher.txt` with the following command after these changes:

Command: `sudo docker run --rm -v ./:/data openstitching/stitch --affine --verbose ./*.jpg`

Result `00_stitcher.txt`:

`AffineStitcher(**{'medium_megapix': 0.6, 'detector': 'orb', 'nfeatures': 500, 'matcher_type': 'affine', 'range_width': -1, 'try_use_gpu': False, 'match_conf': None, 'confidence_threshold': 1, 'matches_graph_dot_file': None, 'estimator': 'affine', 'adjuster': 'affine', 'refinement_mask': 'xxxxx', 'wave_correct_kind': 'no', 'warper_type': 'affine', 'low_megapix': 0.1, 'crop': True, 'compensator': 'no', 'nr_feeds': 1, 'block_size': 32, 'finder': 'dp_color', 'final_megapix': -1, 'blender_type': 'multiband', 'blend_strength': 5, 'timelapse': 'no'})`